### PR TITLE
Boundary edge regions

### DIFF
--- a/examples/examples3d.jl
+++ b/examples/examples3d.jl
@@ -3,12 +3,25 @@
 # 
 
 # ## Quadrilateral
-function quadrilateral()
-    X=collect(0:0.25:1)
-    Y=collect(0:0.2:1)
-    Z=collect(0:0.1:1)
+function quadrilateral(;hx=0.25, hy=0.2, hz=0.1)
+    X=collect(0:hx:1)
+    Y=collect(0:hy:1)
+    Z=collect(0:hz:1)
     simplexgrid(X,Y,Z)
 end
 # ![](quadrilateral.svg)
+
+
+function mask_bedges()
+    grid    = quadrilateral(hx=0.25, hy=0.25, hz=0.25)
+
+    bedgemask!(grid, [0.0, 0.0, 0.0], [0.0, 0.0, 1.0], 1)
+    bedgemask!(grid, [0.0, 0.0, 0.0], [0.0, 1.0, 0.0], 2)
+    bedgemask!(grid, [0.0, 1.0, 0.0], [0.0, 1.0, 1.0], 3)
+    bedgemask!(grid, [0.0, 0.0, 1.0], [0.0, 1.0, 1.0], 4)
+    bedgemask!(grid, [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], 5)
+
+    true
+end
 
 

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -77,7 +77,7 @@ include("subgrid.jl")
 export subgrid
 
 include("more.jl")
-export EdgeNodes, CellEdges,EdgeCells,BFaceCells,BFaceNormals
+export EdgeNodes, CellEdges, EdgeCells, BFaceCells, BFaceNormals, BFaceEdges, BEdgeNodes
 export local_celledgenodes,num_edges
 
 include("regionedit.jl")

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -63,13 +63,16 @@ export ExtendableGrid
 export instantiate, veryform
 export AbstractGridComponent
 export AbstractGridAdjacency,AbstractElementGeometries,AbstractElementRegions
-export Coordinates,CellNodes,BFaceNodes,CellGeometries,BFaceGeometries,CellRegions,BFaceRegions
-export NumCellRegions,NumBFaceRegions,CoordinateSystem
+export Coordinates, CellNodes, BFaceNodes
+export CellGeometries, BFaceGeometries
+export CellRegions, BFaceRegions, BEdgeRegions
+export NumCellRegions, NumBFaceRegions, NumBEdgeRegions
+export CoordinateSystem
 export AbstractGridFloatArray1D,AbstractGridFloatArray2D
 export AbstractGridIntegerArray1D,AbstractGridIntegerArray2D
 export index_type, coord_type
 export dim_space, dim_grid
-export num_nodes, num_cells, num_bfaces, num_cellregions, num_bfaceregions
+export num_nodes, num_cells, num_bfaces, num_bedges, num_cellregions, num_bfaceregions
 export gridcomponents
 export seemingly_equal 
 
@@ -81,7 +84,7 @@ export EdgeNodes, CellEdges, EdgeCells, BFaceCells, BFaceNormals, BFaceEdges, BE
 export local_celledgenodes,num_edges
 
 include("regionedit.jl")
-export cellmask!,bfacemask!
+export cellmask!, bfacemask!, bedgemask!
 
 include("simplexgrid.jl")
 export simplexgrid, geomspace,glue

--- a/src/extendablegrid.jl
+++ b/src/extendablegrid.jl
@@ -143,6 +143,21 @@ Coordinate system
 """
 abstract type CoordinateSystem <: AbstractGridComponent end
 
+
+"""
+$(TYPEDEF)
+
+Boundary edge region number per boundary edge
+"""
+abstract type BEdgeRegions <: AbstractElementRegions end
+
+"""
+$(TYPEDEF)
+
+Number of boundary face regions 
+"""
+abstract type NumBEdgeRegions <: AbstractGridIntegerConstant end
+
 ############################################################
 # Grid type
 
@@ -339,7 +354,21 @@ Instantiate number of bface regions
 """
 instantiate(grid, ::Type{NumBFaceRegions})=maximum(grid[BFaceRegions])
 
+"""
+$(TYPEDSIGNATURES)
 
+Instantiate number of boundary edge regions
+"""
+instantiate(grid, ::Type{NumBEdgeRegions})=maximum(grid[BEdgeRegions])
+
+function prepare_bedgeregions!(grid::ExtendableGrid)
+    bedges             = grid[BEdgeNodes]
+    bedgeregions       = zeros(Int32, num_bedges(grid))
+    grid[BEdgeRegions] = bedgeregions
+end
+
+
+instantiate(grid, ::Type{BEdgeRegions})=prepare_bedgeregions!(grid)
 
 #############################################################
 # General methods
@@ -408,6 +437,14 @@ Number of boundary faces in grid.
 """
 num_bfaces(grid::ExtendableGrid)= haskey(grid,BFaceNodes) ? num_sources(grid[BFaceNodes]) : 0
 
+"""
+$(TYPEDSIGNATURES)
+
+Number of boundary edges in grid.
+"""
+num_bedges(grid::ExtendableGrid)= haskey(grid,BEdgeNodes) ? num_sources(grid[BEdgeNodes]) : 0
+
+
 
 """
 $(TYPEDSIGNATURES)
@@ -423,6 +460,14 @@ $(TYPEDSIGNATURES)
 Maximum  boundary face region numbers
 """
 num_bfaceregions(grid::ExtendableGrid)=grid[NumBFaceRegions]
+
+"""
+$(TYPEDSIGNATURES)
+
+Maximum  boundary edge region numbers
+"""
+num_bedgeregions(grid::ExtendableGrid)=grid[NumBEdgeRegions]
+
 
 """
 $(SIGNATURES)

--- a/src/more.jl
+++ b/src/more.jl
@@ -312,6 +312,15 @@ Number of nodes of 0D vertex
 """
 num_nodes(::Type{Vertex0D})=1
 
+
+"""
+$(SIGNATURES)
+
+Cell-edge node numbering for 1D edge
+"""
+local_celledgenodes(::Type{Vertex0D})=[1]
+
+
 """
 $(SIGNATURES)
 

--- a/src/more.jl
+++ b/src/more.jl
@@ -34,7 +34,19 @@ Adjacency describing outer normals to boundary faces
 """
 abstract type BFaceNormals <: AbstractGridComponent end
 
+"""
+$(TYPEDEF)
 
+Adjacency describing edges per boundary or interior face
+"""
+abstract type BFaceEdges <: AbstractGridAdjacency end
+
+"""
+$(TYPEDEF)
+
+Adjacency describing nodes per boundary or interior edge
+"""
+abstract type BEdgeNodes <: AbstractGridAdjacency end
 
 """
 $(SIGNATURES)
@@ -95,11 +107,11 @@ function prepare_edges!(grid::ExtendableGrid)
 
             # We need to look in nodenod_adj for upper triangular part entries
             # therefore, we need to swap accordingly before looking
-	    if (n1<n2)
-		n0=n1
-		n1=n2
-		n2=n0;
-	    end
+	       if (n1<n2)
+		      n0=n1
+		      n1=n2
+		      n2=n0;
+	       end
             
             for irow=nodenode_adj.colptr[n1]:nodenode_adj.colptr[n1+1]-1
                 if nodenode_adj.rowval[irow]==n2
@@ -142,14 +154,77 @@ ExtendableGrids.instantiate(grid, ::Type{EdgeCells})=prepare_edges!(grid) && gri
 ExtendableGrids.instantiate(grid, ::Type{EdgeNodes})=prepare_edges!(grid) && grid[EdgeNodes]
 
 function prepare_bfacecells!(grid)
-    cn=grid[CellNodes]
-    bn=grid[BFaceNodes]
-    dim=dim_space(grid)
-    abc=asparse(cn)'*asparse(bn)
-    abcx=dropzeros!(SparseMatrixCSC(abc.m,abc.n, abc.colptr, abc.rowval, map( i-> i==dim,  abc.nzval)))
-    grid[BFaceCells]=VariableTargetAdjacency(abcx)
+    cn   = grid[CellNodes]
+    bn   = grid[BFaceNodes]
+    dim  = dim_space(grid)
+    abc  = asparse(cn)'*asparse(bn)
+    abcx = dropzeros!(SparseMatrixCSC(abc.m,abc.n, abc.colptr, abc.rowval, 
+                                      map( i-> i==dim,  abc.nzval)))
+    grid[BFaceCells] = VariableTargetAdjacency(abcx)
     true
 end
+
+function prepare_bedges!(grid)
+    Ti           = eltype(grid[CellNodes])
+    bgeom        = grid[BFaceGeometries][1]
+    bfacenodes   = grid[BFaceNodes]
+    
+    # Create bface-node incidence matrix
+    bfacenode_adj = asparse(bfacenodes)  
+    nodenode_adj = bfacenode_adj*transpose(bfacenode_adj)
+
+    # To get unique edges, we set the lower triangular part
+    # including the diagonal to 0
+    for icol=1:length(nodenode_adj.colptr)-1
+        for irow=nodenode_adj.colptr[icol]:nodenode_adj.colptr[icol+1]-1
+            if nodenode_adj.rowval[irow]>=icol
+                nodenode_adj.nzval[irow]=0
+            end
+        end
+    end
+    dropzeros!(nodenode_adj)
+
+    # Now we know the number of bedges and
+    nbedges=length(nodenode_adj.nzval)
+
+    
+    bedgenodes   = zeros(Ti, 2, nbedges)
+    bfaceedges   = zeros(Ti, num_edges(bgeom), num_bfaces(grid))
+
+    cen        = local_celledgenodes(bgeom)
+    for ibface=1:num_bfaces(grid)
+        for ibedge=1:num_edges(bgeom)
+            n1 = bfacenodes[cen[1,ibedge], ibface]
+            n2 = bfacenodes[cen[2,ibedge], ibface]
+
+            # We need to look in nodenod_adj for upper triangular part entries
+            # therefore, we need to swap accordingly before looking
+           if (n1<n2)
+              n0=n1
+              n1=n2
+              n2=n0;
+           end
+
+            for irow = nodenode_adj.colptr[n1]:nodenode_adj.colptr[n1+1]-1
+                if nodenode_adj.rowval[irow]==n2
+                    # If the coresponding entry has been found, set its
+                    # value. Note that this introduces a different edge orientation
+                    # compared to the one found locally from cell data
+                    bfaceedges[ibedge, ibface] = irow
+                    bedgenodes[1, irow]=n1
+                    bedgenodes[2, irow]=n2
+                end
+            end
+        end
+
+    end
+    grid[BEdgeNodes] = bedgenodes
+    grid[BFaceEdges] = bfaceedges
+    true
+end
+
+ExtendableGrids.instantiate(grid, ::Type{BEdgeNodes})=prepare_bedges!(grid) && grid[BEdgeNodes]
+ExtendableGrids.instantiate(grid, ::Type{BFaceEdges})=prepare_bedges!(grid) && grid[BFaceEdges]
 
 ExtendableGrids.instantiate(grid, ::Type{BFaceCells})=prepare_bfacecells!(grid) && grid[BFaceCells]
 
@@ -248,7 +323,7 @@ const cen_Edge1D=reshape([1 2],:,1)
 """
 $(SIGNATURES)
 
-Cell-edege node numbering for 1D edge
+Cell-edge node numbering for 1D edge
 """
 local_celledgenodes(::Type{Edge1D})=cen_Edge1D
 
@@ -271,7 +346,7 @@ const cen_Triangle2D=[ 2 3 1; 3 1 2]
 """
 $(SIGNATURES)
 
-Cell-edege node numbering for 2D triangle
+Cell-edge node numbering for 2D triangle
 """
 local_celledgenodes(::Type{Triangle2D})=cen_Triangle2D
 
@@ -281,7 +356,7 @@ const cen_Tetrahedron3D=[ 3 4 2  1 1 1; 4 2 3  4 3 2]
 """
 $(SIGNATURES)
 
-Cell-edege node numbering for 2D triangle
+Cell-edge node numbering for 2D triangle
 """
 local_celledgenodes(::Type{Tetrahedron3D})=cen_Tetrahedron3D
 

--- a/src/simplexgrid.jl
+++ b/src/simplexgrid.jl
@@ -44,6 +44,17 @@ function simplexgrid(coord::Array{Tc,2},
     return grid
 end
 
+function simplexgrid(coord::Array{Tc,2},
+                     cellnodes::Array{Ti,2},
+                     cellregions::Array{Ti,1},
+                     bfacenodes::Array{Ti,2},
+                     bfaceregions::Array{Ti,1},
+                     bedgeregions::Array{Ti,1}
+                     ) where {Tc,Ti}
+    grid = simplexgrid(coord, cellnodes, cellregions, bfacenodes, bfaceregions)
+    grid[BEdgeRegions] = bedgeregions
+    return grid
+end
 
 """
 $(TYPEDSIGNATURES)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,6 +128,7 @@ end
 
 @testset "3D" begin
     @test testgrid(quadrilateral(),(330,1200,440))
+    @test mask_bedges()
 end
 
 if !Sys.isapple()


### PR DESCRIPTION
Added boundary edge regions. This is necessary for coupled 3D-2D problems to prescribe boundary conditions for the 2D subproblem. The function `bedgemask!` can be used to associate a region number for boundary edges on a line segment.
So far this works only for boundary edges since `prepare_edges!` doesn't work in the 3D case, yet.

The region numbers are stored in `grid[BEdgeRegions]`, which is only constructed on request, e.g. by calling `bedgemask!`.