### PR TITLE
Added boundary edge regions

### DIFF
--- a/examples/examples3d.jl
+++ b/examples/examples3d.jl
@@ -3,12 +3,25 @@
 # 
 
 # ## Quadrilateral
-function quadrilateral()
-    X=collect(0:0.25:1)
-    Y=collect(0:0.2:1)
-    Z=collect(0:0.1:1)
+function quadrilateral(;hx=0.25, hy=0.2, hz=0.1)
+    X=collect(0:hx:1)
+    Y=collect(0:hy:1)
+    Z=collect(0:hz:1)
     simplexgrid(X,Y,Z)
 end
 # ![](quadrilateral.svg)
+
+
+function mask_bedges()
+    grid    = quadrilateral(hx=0.25, hy=0.25, hz=0.25)
+
+    bedgemask!(grid, [0.0, 0.0, 0.0], [0.0, 0.0, 1.0], 1)
+    bedgemask!(grid, [0.0, 0.0, 0.0], [0.0, 1.0, 0.0], 2)
+    bedgemask!(grid, [0.0, 1.0, 0.0], [0.0, 1.0, 1.0], 3)
+    bedgemask!(grid, [0.0, 0.0, 1.0], [0.0, 1.0, 1.0], 4)
+    bedgemask!(grid, [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], 5)
+
+    true
+end
 
 

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -63,13 +63,17 @@ export ExtendableGrid
 export instantiate, veryform
 export AbstractGridComponent
 export AbstractGridAdjacency,AbstractElementGeometries,AbstractElementRegions
-export Coordinates,CellNodes,BFaceNodes,CellGeometries,BFaceGeometries,CellRegions,BFaceRegions
-export NumCellRegions,NumBFaceRegions,CoordinateSystem
+export Coordinates, CellNodes, BFaceNodes
+export CellGeometries, BFaceGeometries
+export CellRegions, BFaceRegions, BEdgeRegions
+export NumCellRegions, NumBFaceRegions, NumBEdgeRegions
+export CoordinateSystem
 export AbstractGridFloatArray1D,AbstractGridFloatArray2D
 export AbstractGridIntegerArray1D,AbstractGridIntegerArray2D
 export index_type, coord_type
 export dim_space, dim_grid
-export num_nodes, num_cells, num_bfaces, num_cellregions, num_bfaceregions
+export num_nodes, num_cells, num_bfaces, num_bedges 
+export num_cellregions, num_bfaceregions, num_bedgeregions
 export gridcomponents
 export seemingly_equal 
 
@@ -81,7 +85,7 @@ export EdgeNodes, CellEdges, EdgeCells, BFaceCells, BFaceNormals, BFaceEdges, BE
 export local_celledgenodes,num_edges
 
 include("regionedit.jl")
-export cellmask!,bfacemask!
+export cellmask!, bfacemask!, bedgemask!
 
 include("simplexgrid.jl")
 export simplexgrid, geomspace,glue

--- a/src/extendablegrid.jl
+++ b/src/extendablegrid.jl
@@ -143,6 +143,21 @@ Coordinate system
 """
 abstract type CoordinateSystem <: AbstractGridComponent end
 
+"""
+$(TYPEDEF)
+
+Boundary edge region number per boundary edge
+"""
+abstract type BEdgeRegions <: AbstractElementRegions end
+
+"""
+$(TYPEDEF)
+
+Number of boundary edge regions 
+"""
+abstract type NumBEdgeRegions <: AbstractGridIntegerConstant end
+
+
 ############################################################
 # Grid type
 
@@ -340,6 +355,22 @@ Instantiate number of bface regions
 instantiate(grid, ::Type{NumBFaceRegions})=maximum(grid[BFaceRegions])
 
 
+"""
+$(TYPEDSIGNATURES)
+
+Instantiate number of boundary edge regions
+"""
+instantiate(grid, ::Type{NumBEdgeRegions})=maximum(grid[BEdgeRegions])
+
+function prepare_bedgeregions!(grid::ExtendableGrid)
+    bedges             = grid[BEdgeNodes]
+    bedgeregions       = zeros(Int32, num_bedges(grid))
+    grid[BEdgeRegions] = bedgeregions
+end
+
+
+instantiate(grid, ::Type{BEdgeRegions})=prepare_bedgeregions!(grid)
+
 
 #############################################################
 # General methods
@@ -408,6 +439,14 @@ Number of boundary faces in grid.
 """
 num_bfaces(grid::ExtendableGrid)= haskey(grid,BFaceNodes) ? num_sources(grid[BFaceNodes]) : 0
 
+"""
+$(TYPEDSIGNATURES)
+
+Number of boundary edges in grid.
+"""
+num_bedges(grid::ExtendableGrid)= haskey(grid,BEdgeNodes) ? num_sources(grid[BEdgeNodes]) : 0
+
+
 
 """
 $(TYPEDSIGNATURES)
@@ -423,6 +462,17 @@ $(TYPEDSIGNATURES)
 Maximum  boundary face region numbers
 """
 num_bfaceregions(grid::ExtendableGrid)=grid[NumBFaceRegions]
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Maximum boundary edge region numbers
+"""
+num_bedgeregions(grid::ExtendableGrid)=grid[NumBEdgeRegions]
+
+
+
 
 """
 $(SIGNATURES)

--- a/src/regionedit.jl
+++ b/src/regionedit.jl
@@ -122,3 +122,70 @@ function bfacemask!(grid::ExtendableGrid,
     grid[NumBFaceRegions]=max(num_bfaceregions(grid),ireg)
     return grid
 end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Edit region numbers of grid  boundary edges via line mask.
+This only works for 3D grids.
+"""
+function bedgemask!(grid::ExtendableGrid,
+                    xa::AbstractArray,
+                    xb::AbstractArray,
+                    ireg::Int;
+                    tol=1.0e-10)
+    # Masking of boundary edges makes only sense in 3D
+    @assert (dim_space(grid) > 2)
+
+    masked = false
+
+    nbedges        = num_bedges(grid)
+    bedgenodes     = grid[BEdgeNodes]
+    Ti             = eltype(bedgenodes)
+    dim            = dim_space(grid)
+    bedgeregions   = grid[BEdgeRegions]
+    new_bedgenodes = ElasticArray{Ti,2}(bedgenodes)
+    coord          = grid[Coordinates]
+    Tv             = eltype(coord)
+
+    # length of boundary edge region
+    distsq         = sqrt((xa[1]-xb[1])^2 + (xa[2]-xb[2])^2 + (xa[3]-xb[3])^2)
+
+    bedgenodes = grid[BEdgeNodes]
+    # loop over boundary edges
+    for ibedge = 1:size(bedgenodes, 2)
+        in_region = true
+        
+        #loop over nodes of boundary edge
+        for inode=1:num_targets(bedgenodes, ibedge)
+            ignode = bedgenodes[inode, ibedge]
+
+            # we compute the distance of the boundary edge node to the endpoints
+            # if the sum of the distances is larger (with tolerance) than the length
+            # of the boundary region, the point does not lie on the edge
+            distxa = sqrt((xa[1]-coord[1,ignode])^2 
+                     + (xa[2]-coord[2,ignode])^2 
+                     + (xa[3]-coord[3,ignode])^2)
+            distxb = sqrt((coord[1,ignode]-xb[1])^2 
+                     + (coord[2,ignode]-xb[2])^2 
+                     + (coord[3,ignode]-xb[3])^2)
+            diff   = distxa + distxb - distsq 
+            if (diff > tol)
+                in_region = false
+                continue
+            end
+        end
+        
+        if in_region
+            masked = true
+            bedgeregions[ibedge] = ireg
+        end
+    end
+    if !masked
+        @warn "Couldn't mask any boundary edges for region $(ireg)"
+    end
+
+    grid[NumBEdgeRegions]=max(num_bedgeregions(grid),ireg)
+    return grid
+end

--- a/src/simplexgrid.jl
+++ b/src/simplexgrid.jl
@@ -70,6 +70,7 @@ function simplexgrid(coord::Array{Tc,2},
                      bedgeregions::Array{Ti,1}
                      ) where {Tc,Ti}
     grid = simplexgrid(coord, cellnodes, cellregions, bfacenodes, bfaceregions)
+    grid[BEdgeNodes]   = bedgenodes
     grid[BEdgeRegions] = bedgeregions
     return grid
 end

--- a/src/simplexgrid.jl
+++ b/src/simplexgrid.jl
@@ -44,11 +44,29 @@ function simplexgrid(coord::Array{Tc,2},
     return grid
 end
 
+
+"""
+````
+function simplexgrid(coord::Array{Tc,2},
+                     cellnodes::Array{Ti,2},
+                     cellregions::Array{Ti,1},
+                     bfacenodes::Array{Ti,2},
+                     bfaceregions::Array{Ti,1}
+                     bedgenodes::Array{Ti,2},
+                     bedgeregions::Array{Ti,1}
+                     ) where {Tc,Ti}
+````
+
+    Create simplex grid from coordinates, cell-nodes-adjancency, cell-region-numbers,
+    boundary-face-nodes adjacency, boundary-face-region-numbers, boundary-edge-nodes, and
+    boundary-edge-region-numbers arrays.
+"""
 function simplexgrid(coord::Array{Tc,2},
                      cellnodes::Array{Ti,2},
                      cellregions::Array{Ti,1},
                      bfacenodes::Array{Ti,2},
                      bfaceregions::Array{Ti,1},
+                     bedgenodes::Array{Ti,2},
                      bedgeregions::Array{Ti,1}
                      ) where {Tc,Ti}
     grid = simplexgrid(coord, cellnodes, cellregions, bfacenodes, bfaceregions)

--- a/src/simplexgrid.jl
+++ b/src/simplexgrid.jl
@@ -44,6 +44,19 @@ function simplexgrid(coord::Array{Tc,2},
     return grid
 end
 
+function simplexgrid(coord::Array{Tc,2},
+                     cellnodes::Array{Ti,2},
+                     cellregions::Array{Ti,1},
+                     bfacenodes::Array{Ti,2},
+                     bfaceregions::Array{Ti,1},
+                     bedgeregions::Array{Ti,1}
+                     ) where {Tc,Ti}
+    grid = simplexgrid(coord, cellnodes, cellregions, bfacenodes, bfaceregions)
+    grid[BEdgeRegions] = bedgeregions
+    return grid
+end
+
+
 simplexgrid(C,CN,CR,BFN,BFR)=simplexgrid(collect(C),collect(CN),collect(CR),collect(BFN), collect(BFR))
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,6 +140,7 @@ end
 
 @testset "3D" begin
     @test testgrid(quadrilateral(),(330,1200,440))
+    @test mask_bedges()
 end
 
 if !Sys.isapple()


### PR DESCRIPTION
Added boundary edge regions. This is necessary for coupled 3D-2D problems to prescribe boundary conditions for the 2D subproblem. The function `bedgemask!` can be used to associate a region number for boundary edges on a line segment.
So far this works only for boundary edges since prepare_edges! doesn't work in the 3D case, yet.

The region numbers are stored in `grid[BEdgeRegions]`, which is only constructed on request, e.g. by calling `bedgemask!`.