### PR TITLE
Additional Functionality for Subgrids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtendableGrids"
 uuid = "cfc395e8-590f-11e8-1f13-43a2532b2fa8"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Christian Merdon  <christian.merdon@wias-berlin.de>", "Johannes Taraz  <johannes.taraz@gmail.com>"]
-version = "1.2.3"
+version = "1.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -82,7 +82,7 @@ export seemingly_equal, numbers_match
 include("subgrid.jl")
 export subgrid
 export ParentGrid
-export NodeInParent, CellParents, FaceParents, BFaceParents, EdgeParents, BEdgeParents
+export NodeParents, CellParents, FaceParents, BFaceParents, EdgeParents, BEdgeParents
 export ParentGridRelation, SubGrid, BoundarySubGrid, RefinedGrid
 
 include("shape_specs.jl")
@@ -176,6 +176,8 @@ include("io.jl")
 export writeVTK
 
 include("seal.jl")
+
+include("deprecated.jl")
 
 @static if !isdefined(Base, :get_extension)
     function __init__()

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -81,6 +81,9 @@ export seemingly_equal, numbers_match
 
 include("subgrid.jl")
 export subgrid
+export ParentGrid
+export NodeInParent, CellParents, FaceParents
+export ParentGridRelation, SubGrid, BoundarySubGrid, RefinedGrid
 
 include("shape_specs.jl")
 export refcoords_for_geometry
@@ -124,7 +127,6 @@ include("meshrefinements.jl")
 export split_grid_into
 export uniform_refine
 export barycentric_refine
-export CellParents
 
 include("adaptive_meshrefinements.jl")
 export bulk_mark

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -82,7 +82,7 @@ export seemingly_equal, numbers_match
 include("subgrid.jl")
 export subgrid
 export ParentGrid
-export NodeInParent, CellParents, FaceParents
+export NodeInParent, CellParents, FaceParents, BFaceParents, EdgeParents, BEdgeParents
 export ParentGridRelation, SubGrid, BoundarySubGrid, RefinedGrid
 
 include("shape_specs.jl")

--- a/src/adaptive_meshrefinements.jl
+++ b/src/adaptive_meshrefinements.jl
@@ -104,6 +104,7 @@ function RGB_refine(source_grid::ExtendableGrid{T,K}, facemarkers::Array{Bool,1}
     oldFaceNodes = source_grid[FaceNodes]
     nfaces = num_sources(oldFaceNodes)
     ncells = num_sources(oldCellNodes)
+    xCellParents::Array{K,1} = zeros(K,0)
 
     # closuring
     # @logmsg MoreInfo "RGB refinement with $(sum(facemarkers)) marked faces"
@@ -189,6 +190,7 @@ function RGB_refine(source_grid::ExtendableGrid{T,K}, facemarkers::Array{Bool,1}
             append!(xCellNodes,view(subitemnodes,:))
             push!(xCellGeometries,Triangle2D)
             push!(xCellRegions,oldCellRegions[cell])
+            push!(xCellParents,cell)
         end    
         ncells += nnewcells
     end
@@ -249,6 +251,9 @@ function RGB_refine(source_grid::ExtendableGrid{T,K}, facemarkers::Array{Bool,1}
     xgrid[BFaceNodes] = reshape(xBFaceNodes,(2,nbfaces+newbfaces))
     xgrid[BFaceRegions] = xBFaceRegions
     xgrid[BFaceGeometries] = VectorOfConstants{ElementGeometries,Int}(Edge1D,nbfaces+newbfaces)
+    xgrid[ParentGrid] = source_grid
+    xgrid[ParentGridRelation] = RefinedGrid
+    xgrid[CellParents] = xCellParents 
 
     return xgrid
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,8 @@
+## NodeInParent was renamed to NodeParents in v1.3
+abstract type NodeInParent <: AbstractGridIntegerArray1D end
+export NodeInParent 
+
+function ExtendableGrids.instantiate(xgrid::ExtendableGrid, ::Type{NodeInParent})
+    @warn "NodeInParents is deprecated, use NodeParents instead"
+    xgrid[NodeParents]
+end

--- a/src/derived.jl
+++ b/src/derived.jl
@@ -256,7 +256,7 @@ function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{FaceNo
             end
             pcell2scell = zeros(Ti, npcells)
             pcell2scell[pcells] = 1:length(pcells)
-            xgrid[CellFaces] = pgrid[CellFaces][:, pcells]
+            xgrid[CellFaces] = PCellFaces[:, pcells]
             xgrid[CellFaceSigns] = pgrid[CellFaceSigns][:, pcells]
             SFaceCells = pgrid[FaceCells][:, pfaces]
             for face = 1 : 1:length(pfaces)

--- a/src/derived.jl
+++ b/src/derived.jl
@@ -201,7 +201,7 @@ function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{FaceNo
         if xgrid[ParentGridRelation] === SubGrid
             ## get FaceNodes from ParentGrid to keep ordering and orientation
             pgrid = xgrid[ParentGrid]
-            pnodes = xgrid[NodeInParent]
+            pnodes = xgrid[NodeParents]
             nscells = num_cells(xgrid)
             PFaceNodes = pgrid[FaceNodes]
             PCellFaces = deepcopy(pgrid[CellFaces])

--- a/src/meshrefinements.jl
+++ b/src/meshrefinements.jl
@@ -42,6 +42,7 @@ function split_grid_into(source_grid::ExtendableGrid{T,K}, targetgeometry::Type{
     itemEG = EG[1]
     iEG::Int = 1
     split_rule::Array{Int,2} = split_rules[iEG]
+    xCellParents::Array{K,1} = zeros(K,0)
     for cell = 1 : num_sources(oldCellNodes)
         if !singleEG
             nnodes4item = num_targets(oldCellNodes,cell)
@@ -54,6 +55,7 @@ function split_grid_into(source_grid::ExtendableGrid{T,K}, targetgeometry::Type{
         end    
         for j = 1 : size(split_rule,2)
             push!(xCellRegions,oldCellRegions[cell])
+            push!(xCellParents,cell)
         end
         ncells += size(split_rule,2)
     end
@@ -126,6 +128,10 @@ function split_grid_into(source_grid::ExtendableGrid{T,K}, targetgeometry::Type{
         xgrid[BFaceRegions]=newBFaceRegions
         xgrid[BFaceGeometries]=VectorOfConstants{ElementGeometries,Int}(facetype_of_cellface(targetgeometry,1),newnbfaces)
     end
+
+    xgrid[ParentGrid] = source_grid
+    xgrid[ParentGridRelation] = RefinedGrid
+    xgrid[CellParents] = xCellParents
 
     return xgrid
 end

--- a/src/subgrid.jl
+++ b/src/subgrid.jl
@@ -1,9 +1,9 @@
 """
 $(TYPEDEF)
 
-Grid component key type for storing node in parent array
+Grid component key type for storing node parents (=ids of nodes in ParentGrid) in an array
 """
-abstract type NodeInParent <: AbstractGridIntegerArray1D end
+abstract type NodeParents <: AbstractGridIntegerArray1D end
 
 """
 $(TYPEDEF)
@@ -98,7 +98,7 @@ Create subgrid from list of regions.
 - `project`: project coordinates onto  subgrid dimension
 
 A subgrid is of type `ExtendableGrid` and stores two additional components:
-[`ParentGrid`](@ref) and [`NodeInParent`](@ref)
+[`ParentGrid`](@ref) and [`NodeParents`](@ref)
 
 """
 function subgrid(parent,
@@ -195,7 +195,7 @@ function subgrid(parent,
     subgrid[CellGeometries]=sub_ct
     subgrid[CellNodes]=tryfix(sub_xnodes)
     subgrid[ParentGrid]=parent
-    subgrid[NodeInParent]=sub_nip
+    subgrid[NodeParents]=sub_nip
     subgrid[CellParents]=cellparents
     subgrid[ParentGridRelation]=boundary ? BoundarySubGrid : SubGrid
 
@@ -265,7 +265,7 @@ function subgrid(parent,
         # Sort nodes of grid for easy plotting
         X=view(subgrid[Coordinates],1,:)
         nx=length(X)
-        I=subgrid[NodeInParent]
+        I=subgrid[NodeParents]
         xipairs=[XIPair{Tc,Ti}(X[i],I[i]) for i=1:nx]
         sort!(xipairs, 1,nx, Base.QuickSort, Base.Forward)
         for i=1:nx
@@ -297,7 +297,7 @@ $(TYPEDSIGNATURES)
 
 Create a view of the vector on a subgrid.
 """
-Base.view(a::AbstractVector,subgrid::ExtendableGrid)  = SubgridVectorView(a,subgrid[NodeInParent])
+Base.view(a::AbstractVector,subgrid::ExtendableGrid)  = SubgridVectorView(a,subgrid[NodeParents])
 
 
 ##############################################################################

--- a/src/subgrid.jl
+++ b/src/subgrid.jl
@@ -194,8 +194,13 @@ function subgrid(parent,
     
         subgrid[BFaceRegions]=sub_bfaceregions
         subgrid[BFaceGeometries]=sub_bfacetypes
-        subgrid[BFaceNodes]=tryfix(sub_bfacenodes)
-        subgrid[NumBFaceRegions]=maximum(sub_bfaceregions)
+        if length(sub_bfaceregions) > 1
+            subgrid[BFaceNodes]=tryfix(sub_bfacenodes)
+            subgrid[NumBFaceRegions]=maximum(sub_bfaceregions)
+        else
+            subgrid[BFaceNodes]=zeros(Ti, 2, 0)
+            subgrid[NumBFaceRegions]=0
+        end
     end
     subgrid[CoordinateSystem]=parent[CoordinateSystem]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,6 +181,50 @@ end
     @test g[Coordinates] ≈ gxyz[Coordinates]
 end
 
+
+@testset "ParentGridRelation-SubGrid" begin
+    ## generate a subgrid
+    grid = grid_unitsquare(Triangle2D)
+    grid[CellRegions] = Int32[1,2,2,1]
+    sgrid = subgrid(grid, [1])
+    @test sgrid[ParentGridRelation] == SubGrid
+
+    ## check if CellParents are assigned correctly
+    @test sgrid[CellParents] == [1,4]
+
+    ## check if FaceNodes couple correctly with FaceNodes in parent grid
+    facenodes = sgrid[FaceNodes]
+    bfacenodes = sgrid[BFaceNodes]
+    parentnodes = sgrid[NodeInParent]
+    parentfaces = sgrid[FaceParents]
+    parentbfaces = sgrid[BFaceParents]
+    @test all(parentnodes[facenodes] .== grid[FaceNodes][:, parentfaces])
+    @test all(parentnodes[bfacenodes] .== grid[BFaceNodes][:,parentbfaces])
+end
+
+@testset "ParentGridRelation-RefinedGrid" begin
+    ## generate a refined 
+    grid = grid_unitsquare(Triangle2D)
+    
+    ## check uniform refinement
+    rgrid = uniform_refine(grid)
+    @test rgrid[ParentGridRelation] == RefinedGrid
+
+    ## check if CellParents and BFaceParents are set
+    @test length(rgrid[CellParents]) == 4*num_cells(grid)
+    @test length(rgrid[BFaceParents]) == 2*num_bfaces(grid)
+
+    ## check barycentric refinement
+    rgrid = barycentric_refine(grid)
+    @test rgrid[ParentGridRelation] == RefinedGrid
+
+    ## check if CellParents and BFaceParents are set
+    @test length(rgrid[CellParents]) == 3*num_cells(grid)
+    @test length(rgrid[BFaceParents]) == num_bfaces(grid)
+
+
+end
+
 function tglue(; dim = 2, breg = 0)
     X1 = linspace(0, 1, 5)
     Y1 = linspace(0, 1, 5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,7 +146,7 @@ end
 end
 
 @testset "subgrid+extrusion" begin
-    function subgen(; h = 0.2)
+    function subgen(; region = 1, h = 0.2)
         X = collect(-1:h:2)
         Y = collect(0:h:1)
         Z = collect(0:h:2)
@@ -158,6 +158,8 @@ end
         # Mark cut-out regions as 2
         cellmask!(g, [-1, 0, 0], [0, 1, 1], 2)
         cellmask!(g, [1, 0, 0], [2, 1, 1], 2)
+        # Mark interior region 3 with region 2
+        cellmask!(g, [-0.75,0.25,0.25], [-0.25,0.75,0.75], 3)
 
         # add new interface elements
         bfacemask!(g, [-1, 0, 1], [2, 1, 1], 3; allow_new = true)
@@ -165,8 +167,10 @@ end
         bfacemask!(g, [1, 0, 0], [1, 1, 1], 3; allow_new = true)
 
         # return subgrid of region 1
-        subgrid(g, [1])
+        subgrid(g, [region])
     end
+    sub2 = subgen(; region = 3)
+    
     @test numbers_match(subgen(), 756, 3000, 950)
 
     X = collect(0:0.25:1)


### PR DESCRIPTION
This PR adds additional subgrid functionality, namely:
- CellParents, BFaceParents components already stored by subgrid generation
- ParentGridRelation to determine if ParentGrid was created by subgrid (SubGrid or BoundarySubGrid) or one of the refinement produces (RefinedGrid)

When FaceNodes is instantiated for a grid that has a ParentGrid with SubGrid relation, first the FaceNodes of the parent grid are instantiated and then the faces that are also part of the subgrid are strided (and their node ids are remapped to the subgrid nodes ids) such that the orientation stays inline with the parent grid. Additionaly, FaceParents are stored to know the number of the subgrid faces in the parent grid.

Todo: if the new behavior is accepted, some tests should be added and EdgeNodes should get a similar behaviour; the refinement procedures currently store CellParents, but should also store BFaceParents for consistent behaviour (one could also think if one wants to have a certain FaceNodes behaviour for grids that are RefinedGrids of their parent grid, but I currently don't see the need for that)

Goal: correct management of finite element degrees of freedom for finite element spaces that are defined on subgrids in ExtendableFEMBase