### PR TITLE
Add  test for undocumented names on Julia 1.11

### DIFF
--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -1,3 +1,9 @@
+"""
+    ExtendableGrids
+
+Package providing container structure `ExtendableGrid` with type stable content access and lazy content creation holding data for discretization
+grids for finite element and finite volume methods. 
+"""
 module ExtendableGrids
 
 using DocStringExtensions

--- a/src/simplexgrid.jl
+++ b/src/simplexgrid.jl
@@ -91,8 +91,23 @@ end
 
 
 ##########################################################
+
+"""
+    $(TYPEDEF)
+X coordinates of simplex grid derived from tensor product
+"""
 abstract type XCoordinates <: AbstractGridFloatArray1D end
+
+"""
+    $(TYPEDEF)
+Y coordinates of simplex grid derived from tensor product
+"""
 abstract type YCoordinates <: AbstractGridFloatArray1D end
+
+"""
+    $(TYPEDEF)
+Z coordinates of simplex grid derived from tensor product
+"""
 abstract type ZCoordinates <: AbstractGridFloatArray1D end
 
 

--- a/test/gmsh.jl
+++ b/test/gmsh.jl
@@ -1,5 +1,3 @@
-using Gmsh: gmsh
-
 # Add this later as an verbosity option
 #  gmsh.option.setNumber("General.Terminal", 0)
 #  gmsh.option.setNumber("General.Verbosity", 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,19 +1,33 @@
 using Test, Aqua
 using ExampleJuggler
+using Gmsh: gmsh
 
 using ExtendableGrids, SHA
 
 using AbstractTrees, StatsBase
+@show pkgdir(ExtendableGrids)
+@show :grid_unitcube ∈ Docs.undocumented_names(ExtendableGrids)
+
+@testset "undocumented names" begin
+    undocnames=Docs.undocumented_names(ExtendableGrids)
+    @test isempty(undocnames)
+end
+
+end
+
 
 @testset "Aqua" begin
-Aqua.test_ambiguities([ExtendableGrids, Base, Core], exclude=[view, ==, StatsBase.TestStat, copyto!])
-Aqua.test_unbound_args(ExtendableGrids)
-Aqua.test_undefined_exports(ExtendableGrids)
-Aqua.test_project_extras(ExtendableGrids)
-Aqua.test_stale_deps(ExtendableGrids,ignore=[:Requires,:Bijections])
-Aqua.test_deps_compat(ExtendableGrids)
-Aqua.test_piracies(ExtendableGrids,treat_as_own=[AbstractTrees.children])
-Aqua.test_persistent_tasks(ExtendableGrids)
+    # not sure why copyto! and StatsBase are popping up here
+    Aqua.test_ambiguities([ExtendableGrids, Base, Core], exclude=[view, ==, StatsBase.TestStat, copyto!])
+    Aqua.test_unbound_args(ExtendableGrids)
+    Aqua.test_undefined_exports(ExtendableGrids)
+    Aqua.test_project_extras(ExtendableGrids)
+    Aqua.test_stale_deps(ExtendableGrids,ignore=[:Requires,:Bijections])
+    Aqua.test_deps_compat(ExtendableGrids)
+
+    # Guilty of pirating: AbstracTrees.children(::Type)...
+    Aqua.test_piracies(ExtendableGrids,treat_as_own=[AbstractTrees.children])
+    Aqua.test_persistent_tasks(ExtendableGrids)
 end
 
 


### PR DESCRIPTION
This PR adds a test on Julia 1.11 which has `Docs.undocumented_names`.
When accepted this will run for  the nightly tests.

As `warnonly=true` has been removed from the makedocs kwargs, newly added docstrings must also occur somewhere in the generated doc (which in the moment is not well sorted,  but at least we will be able to make everything findable...)

Currently, thse are:
```
AssemblyType
BEdgeAssemblyGroups
BEdgeEdges
BEdgeGeometries
BEdgeNodes
BEdgeVolumes
BFaceAssemblyGroups
BFaceCellPos
BFaceFaces
BFaceVolumes
CellAssemblyGroups
CellEdgeSigns
CellEdges
CellFaceOrientations
CellFaceSigns
CellFaces
CellVolumes
CoordinateSystems
EdgeAssemblyGroups
EdgeCells
EdgeGeometries
EdgeNodes
EdgeRegions
EdgeTangents
EdgeVolumes
ElementGeometries
FaceAssemblyGroups
FaceCells
FaceEdgeSigns
FaceEdges
FaceGeometries
FaceNodes
FaceNormals
FaceRegions
FaceVolumes
GridComponent4TypeProperty
GridComponentAssemblyGroups4AssemblyType
GridComponentGeometries4AssemblyType
GridComponentNodes4AssemblyType
GridComponentRegions4AssemblyType
GridComponentUniqueGeometries4AssemblyType
GridComponentVolumes4AssemblyType
GridRegionTypes
ITEMTYPE_BEDGE
ITEMTYPE_BFACE
ITEMTYPE_CELL
ITEMTYPE_EDGE
ITEMTYPE_FACE
ItemType4AssemblyType
NodeInParent
NodePatchGroups
Normal4ElemType!
PROPERTY_ASSEMBLYGROUP
PROPERTY_GEOMETRY
PROPERTY_NODES
PROPERTY_REGION
PROPERTY_UNIQUEGEOMETRY
PROPERTY_VOLUME
Tangent4ElemType!
UniqueBEdgeGeometries
UniqueBFaceGeometries
UniqueCellGeometries
UniqueEdgeGeometries
UniqueFaceGeometries
bulk_mark
eval_trafo!
get_bfacegrid
get_edgegrid
get_facegrid
mapderiv!
numbers_match
update_trafo!
xrefFACE2xrefCELL
xrefFACE2xrefOFACE
```
