### PR TITLE
Reinstantiation of CellVolumes, FaceNormals etc.

### DIFF
--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -63,6 +63,7 @@ export Polar2D, Polar1D, Spherical3D, Spherical1D
 include("extendablegrid.jl")
 export ExtendableGrid
 export instantiate, veryform
+export update!
 export AbstractGridComponent
 export AbstractGridAdjacency, AbstractElementGeometries, AbstractElementRegions
 export Coordinates, CellNodes, BFaceNodes

--- a/src/derived.jl
+++ b/src/derived.jl
@@ -1009,14 +1009,20 @@ function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{CellFa
     xgrid[CellFaceSigns]
 end
 
-function collectVolumes4Geometries(T::Type{<:Real}, xgrid::ExtendableGrid{Tc,Ti}, ItemType) where {Tc,Ti}
+function collectVolumes4Geometries(xgrid::ExtendableGrid{Tc,Ti}, ItemType) where {Tc,Ti}
     # get links to other stuff
     xCoordinates = xgrid[Coordinates]
     xCoordinateSystem = xgrid[CoordinateSystem]
     xItemNodes = xgrid[GridComponent4TypeProperty(ItemType,PROPERTY_NODES) ]
     xGeometries = xgrid[GridComponent4TypeProperty(ItemType,PROPERTY_GEOMETRY) ]
     nitems = num_sources(xItemNodes)
-    xVolumes = zeros(T,nitems)
+
+    # keep existing volume array if possible
+    if haskey(xgrid.components, GridComponent4TypeProperty(ItemType, PROPERTY_VOLUME))
+        xVolumes = xgrid[GridComponent4TypeProperty(ItemType,PROPERTY_VOLUME)]
+    else
+        xVolumes = zeros(Tc,nitems)
+    end
 
     # Introduce a function barrier: this will be compiled for each differnent type
     # of coordinate systems.
@@ -1032,23 +1038,23 @@ end
 
 
 function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{CellVolumes}) where {Tc,Ti}
-    collectVolumes4Geometries(Tc, xgrid, ITEMTYPE_CELL)
+    collectVolumes4Geometries(xgrid, ITEMTYPE_CELL)
 end
 
 function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{FaceVolumes}) where {Tc,Ti}
-    collectVolumes4Geometries(Tc, xgrid, ITEMTYPE_FACE)
+    collectVolumes4Geometries(xgrid, ITEMTYPE_FACE)
 end
 
 function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{BFaceVolumes}) where {Tc,Ti}
-    collectVolumes4Geometries(Tc, xgrid, ITEMTYPE_BFACE)
+    collectVolumes4Geometries(xgrid, ITEMTYPE_BFACE)
 end
 
 function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{EdgeVolumes}) where {Tc,Ti}
-    collectVolumes4Geometries(Tc, xgrid, ITEMTYPE_EDGE)
+    collectVolumes4Geometries(xgrid, ITEMTYPE_EDGE)
 end
 
 function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{BEdgeVolumes}) where {Tc,Ti}
-    collectVolumes4Geometries(Tc, xgrid, ITEMTYPE_BEDGE)
+    collectVolumes4Geometries(xgrid, ITEMTYPE_BEDGE)
 end
 
 
@@ -1269,7 +1275,9 @@ function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{FaceNo
     nfaces::Int = num_sources(xFaceNodes)
     xFaceGeometries::GridEGTypes = xgrid[FaceGeometries]
     xCoordinateSystem::Type{<:AbstractCoordinateSystem} = xgrid[CoordinateSystem]
-    xFaceNormals::Array{Tc,2} = zeros(Tc,dim,nfaces)
+
+    xFaceNormals::Array{Tc,2} = haskey(xgrid.components, FaceNormals) ? xgrid[FaceNormals] : zeros(Tc,dim,nfaces)
+
     normal::Array{Tc,1} = zeros(Tc,dim)
     EG = xFaceGeometries[1]
     for face = 1 : nfaces
@@ -1290,7 +1298,9 @@ function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{EdgeTa
     nedges::Int = num_sources(xEdgeNodes)
     xEdgeGeometries::GridEGTypes = xgrid[EdgeGeometries]
     xCoordinateSystem::Type{<:AbstractCoordinateSystem} = xgrid[CoordinateSystem]
-    xEdgeTangents::Array{Tc,2} = zeros(Tc,dim,nedges)
+
+    xEdgeTangents::Array{Tc,2} = haskey(xgrid.components, EdgeTangents) ? xgrid[EdgeTangents] : zeros(Tc,dim,nedges)
+
     EG = xEdgeGeometries[1]
     tangent::Array{Tc,1} = zeros(Tc,dim)
     for edge = 1 : nedges

--- a/src/extendablegrid.jl
+++ b/src/extendablegrid.jl
@@ -259,6 +259,13 @@ Base.delete!(grid::ExtendableGrid, T::Type{<:AbstractGridComponent}) = delete!(g
 """
 $(TYPEDSIGNATURES)
 
+Reinstantiate grid component (only if it exists)
+"""
+update!(grid::ExtendableGrid, T::Type{<:AbstractGridComponent}) = haskey(grid, T) ? instantiate(grid, T) : nothing
+
+"""
+$(TYPEDSIGNATURES)
+
 To be called by getindex. This triggers lazy creation of 
 non-existing gridcomponents
 """


### PR DESCRIPTION
- added update! function to trigger reinstationation of cell components
- CellVolumes, FaceVolumes etc. and FaceNormals and EdgeTangents now keep existing arrays

Example:
update!(grid, CellVolumes)
checks if CellVolumes exists and only then triggers instantiate(grid, CellVolumes) which then keeps the existing array and just updates the values

