### PR TITLE
extended subgrid functionality

### DIFF
--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -119,7 +119,6 @@ export CellAssemblyGroups, FaceAssemblyGroups, BFaceAssemblyGroups, EdgeAssembly
 export GridComponent4TypeProperty
 export ITEMTYPE_CELL, ITEMTYPE_FACE, ITEMTYPE_BFACE, ITEMTYPE_EDGE, ITEMTYPE_BEDGE
 export PROPERTY_NODES, PROPERTY_REGION, PROPERTY_VOLUME, PROPERTY_UNIQUEGEOMETRY, PROPERTY_GEOMETRY, PROPERTY_ASSEMBLYGROUP
-export get_facegrid, get_bfacegrid, get_edgegrid
 export GridEGTypes
 export GridRegionTypes
 

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -88,8 +88,8 @@ export AbstractPartitioningAlgorithm, TrivialPartitioning, PlainMetisPartitionin
 include("subgrid.jl")
 export subgrid
 export ParentGrid
-export NodeParents, CellParents, FaceParents, BFaceParents
-export ParentGridRelation, SubGrid, BoundarySubGrid, RefinedGrid
+export NodeParents, CellParents, FaceParents, BFaceParents, EdgeParents, BEdgeParents
+export ParentGridRelation, SubGrid, RefinedGrid
 
 include("shape_specs.jl")
 export refcoords_for_geometry
@@ -99,6 +99,7 @@ export num_edges
 export local_cellfacenodes
 export local_celledgenodes
 export facetype_of_cellface
+export Volume4ElemType
 export Normal4ElemType!
 export Tangent4ElemType!
 export xrefFACE2xrefCELL

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -85,10 +85,21 @@ export num_pcolors, num_partitions, pcolors, pcolor_partitions, partition_cells,
 export partition, num_partitions_per_color,check_partitioning
 export AbstractPartitioningAlgorithm, TrivialPartitioning, PlainMetisPartitioning
 
+include("assemblytypes.jl")
+export AssemblyType
+export AT_NODES, ON_CELLS, ON_FACES, ON_IFACES, ON_BFACES, ON_EDGES, ON_BEDGES
+export ItemType4AssemblyType
+export GridComponentNodes4AssemblyType
+export GridComponentVolumes4AssemblyType
+export GridComponentGeometries4AssemblyType
+export GridComponentRegions4AssemblyType
+export GridComponentUniqueGeometries4AssemblyType
+export GridComponentAssemblyGroups4AssemblyType
+
 include("subgrid.jl")
 export subgrid
 export ParentGrid
-export NodeParents, CellParents, FaceParents, BFaceParents, EdgeParents, BEdgeParents
+export NodeParents, CellParents, FaceParents, BFaceParents
 export ParentGridRelation, SubGrid, RefinedGrid
 
 include("shape_specs.jl")
@@ -99,7 +110,6 @@ export num_edges
 export local_cellfacenodes
 export local_celledgenodes
 export facetype_of_cellface
-export Volume4ElemType
 export Normal4ElemType!
 export Tangent4ElemType!
 export xrefFACE2xrefCELL
@@ -137,17 +147,6 @@ export barycentric_refine
 include("adaptive_meshrefinements.jl")
 export bulk_mark
 export RGB_refine
-
-include("assemblytypes.jl")
-export AssemblyType
-export AT_NODES, ON_CELLS, ON_FACES, ON_IFACES, ON_BFACES, ON_EDGES, ON_BEDGES
-export ItemType4AssemblyType
-export GridComponentNodes4AssemblyType
-export GridComponentVolumes4AssemblyType
-export GridComponentGeometries4AssemblyType
-export GridComponentRegions4AssemblyType
-export GridComponentUniqueGeometries4AssemblyType
-export GridComponentAssemblyGroups4AssemblyType
 
 include("l2gtransformations.jl")
 export L2GTransformer, update_trafo!, eval_trafo!, mapderiv!

--- a/src/derived.jl
+++ b/src/derived.jl
@@ -125,42 +125,6 @@ GridComponent4TypeProperty(::Type{ITEMTYPE_BEDGE},::Type{PROPERTY_GEOMETRY}) = B
 GridComponent4TypeProperty(::Type{ITEMTYPE_BEDGE},::Type{PROPERTY_UNIQUEGEOMETRY}) = UniqueBEdgeGeometries
 GridComponent4TypeProperty(::Type{ITEMTYPE_BEDGE},::Type{PROPERTY_ASSEMBLYGROUP}) = BEdgeAssemblyGroups
 
-
-function get_facegrid(source_grid::ExtendableGrid{Tc,Ti}) where {Tc,Ti}
-    facegrid=ExtendableGrid{Tc,Ti}()
-    facegrid[Coordinates]=source_grid[Coordinates]
-    facegrid[CellNodes]=source_grid[FaceNodes]
-    facegrid[CoordinateSystem]=source_grid[CoordinateSystem]
-    facegrid[CellGeometries]=source_grid[FaceGeometries]
-    facegrid[UniqueCellGeometries]=source_grid[UniqueFaceGeometries]
-    facegrid[CellRegions] = source_grid[FaceRegions]
-    # todo: facegrid[CellFaces] = source_grid[FaceEdges]
-    return facegrid
-end
-
-function get_bfacegrid(source_grid::ExtendableGrid{Tc,Ti})  where {Tc,Ti}
-    bfacegrid=ExtendableGrid{Tc,Ti}()
-    bfacegrid[Coordinates]=source_grid[Coordinates]
-    bfacegrid[CellNodes]=source_grid[BFaceNodes]
-    bfacegrid[CoordinateSystem]=source_grid[CoordinateSystem]
-    bfacegrid[CellGeometries]=source_grid[BFaceGeometries]
-    bfacegrid[UniqueCellGeometries]=source_grid[UniqueBFaceGeometries]
-    bfacegrid[CellRegions] = source_grid[BFaceRegions]
-    # todo: bfacegrid[CellFaces] = source_grid[BFaceEdges] (or sub-view of FaceEdges ?)
-    return bfacegrid
-end
-
-function get_edgegrid(source_grid::ExtendableGrid{Tc,Ti}) where {Tc,Ti}
-    edgegrid=ExtendableGrid{Tc,Ti}()
-    edgegrid[Coordinates]=source_grid[Coordinates]
-    edgegrid[CellNodes]=source_grid[EdgeNodes]
-    edgegrid[CoordinateSystem]=source_grid[CoordinateSystem]
-    edgegrid[CellGeometries]=source_grid[EdgeGeometries]
-    edgegrid[UniqueCellGeometries]=source_grid[UniqueedgeGeometries]
-    edgegrid[CellRegions] = source_grid[EdgeRegions]
-    return edgegrid
-end
-
 # show function for ExtendableGrids and defined Components in its Dict
 function showmore(io::IO, xgrid::ExtendableGrid{Tc,Ti}) where {Tc,Ti}
 
@@ -198,7 +162,7 @@ end
 function ExtendableGrids.instantiate(xgrid::ExtendableGrid{Tc,Ti}, ::Type{FaceNodes}) where {Tc,Ti}
 
     if haskey(xgrid, ParentGrid) && haskey(xgrid, ParentGridRelation)
-        if xgrid[ParentGridRelation] === SubGrid
+        if xgrid[ParentGridRelation] <: SubGrid{ON_CELLS}
             ## get FaceNodes from ParentGrid to keep ordering and orientation
             pgrid = xgrid[ParentGrid]
             pnodes = xgrid[NodeParents]

--- a/src/subgrid.jl
+++ b/src/subgrid.jl
@@ -46,7 +46,7 @@ $(TYPEDEF)
 
 Grid component key type for indicating that grid is a subgrid of the parentgrid
 """
-abstract type SubGrid{based} <: ParentGridRelation where {based <: AssemblyType} end
+abstract type SubGrid{support} <: ParentGridRelation where {support <: AssemblyType} end
 
 """
 $(TYPEDEF)
@@ -109,7 +109,7 @@ function subgrid(parent,
                  coordinatesystem=codim1_coordinatesystem(parent[CoordinateSystem]),
                  project=true) where T
 
-    @assert support in [ON_CELLS, ON_FACES, ON_BFACES] "value ($based) for 'support' is not allowed"
+    @assert support in [ON_CELLS, ON_FACES, ON_BFACES] "value ($support) for 'support' is not allowed"
 
     if boundary
         support = ON_BFACES

--- a/src/subgrid.jl
+++ b/src/subgrid.jl
@@ -218,6 +218,9 @@ function subgrid(parent,
         subgrid[BFaceGeometries]=ElementGeometries[]
         subgrid[BFaceNodes]=Matrix{Ti}(undef,sub_gdim,0)
         subgrid[NumBFaceRegions]=0
+        if !isnothing(coordinatesystem)
+            subgrid[CoordinateSystem]=coordinatesystem
+        end
     else
         bfacenodes=parent[BFaceNodes]
         bfaceregions=parent[BFaceRegions]
@@ -271,8 +274,8 @@ function subgrid(parent,
             subgrid[BFaceNodes]=zeros(Ti, 2, 0)
             subgrid[NumBFaceRegions]=0
         end
+        subgrid[CoordinateSystem]=parent[CoordinateSystem]
     end
-    subgrid[CoordinateSystem]=parent[CoordinateSystem]
 
     if sub_gdim == 1
         # Sort nodes of grid for easy plotting

--- a/src/subgrid.jl
+++ b/src/subgrid.jl
@@ -106,8 +106,8 @@ function subgrid(parent,
                  transform::T=function(a,b) @views a.=b[1:length(a)] end,                                      
                  boundary=false,
                  support=ON_CELLS,
-                 coordinatesystem=codim1_coordinatesystem(parent[CoordinateSystem]),
-                 project=true) where T
+                 project=true,
+                 coordinatesystem=project ? codim1_coordinatesystem(parent[CoordinateSystem]) : parent[CoordinateSystem]) where T
 
     @assert support in [ON_CELLS, ON_FACES, ON_BFACES] "value ($support) for 'support' is not allowed"
 
@@ -133,13 +133,11 @@ function subgrid(parent,
     if support == ON_BFACES
         xregions=parent[BFaceRegions]
         xnodes=parent[BFaceNodes]
-        sub_gdim=dim_grid(parent)-1
         xct=parent[BFaceGeometries]
         sub_gdim=dim_grid(parent)-1
     elseif support == ON_FACES
         xregions=parent[FaceRegions]
         xnodes=parent[FaceNodes]
-        sub_gdim=dim_grid(parent)-1
         xct=parent[FaceGeometries]
         sub_gdim=dim_grid(parent)-1
     elseif support == ON_CELLS
@@ -277,7 +275,7 @@ function subgrid(parent,
         subgrid[CoordinateSystem]=parent[CoordinateSystem]
     end
 
-    if sub_gdim == 1
+    if sub_gdim == 1 && project
         # Sort nodes of grid for easy plotting
         X=view(subgrid[Coordinates],1,:)
         nx=length(X)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -243,7 +243,7 @@ end
     grid = grid_unitsquare(Triangle2D)
     grid[CellRegions] = Int32[1,2,2,1]
     sgrid = subgrid(grid, [1])
-    @test sgrid[ParentGridRelation] == SubGrid
+    @test sgrid[ParentGridRelation] == SubGrid{ON_CELLS}
 
     ## check if CellParents are assigned correctly
     @test sgrid[CellParents] == [1,4]


### PR DESCRIPTION
extended subgrid features:
- new argument 'support' which can be ON_CELLS (default subgrid behaviour as before), ON_BFACES (default subgrid behaviour with boundary = true which also still works) and ON_FACES (new behaviour that generates a subgrid with faces)
- SubGrid type has now a parameter that knows the support relative to parent grid, removed BoundarySubGrid type
- removed get_facegrid, get_bfacegrid, get_edgegrid in derived.jl (that offer no new functionality compared to subgrid)