### PR TITLE
fix negative CellVolumes for grids from 3D simplexgrid constructor

### DIFF
--- a/src/simplexgrid.jl
+++ b/src/simplexgrid.jl
@@ -477,11 +477,11 @@ function  simplexgrid(_X::AbstractVector,_Y::AbstractVector,_Z::AbstractVector; 
 	        p111 = ip+1+nx+nxy;
 
                 icell=icell+1;  @. cellnodes[:,icell]=(p000,p100,p110,p111)
-		icell=icell+1;	@. cellnodes[:,icell]=(p000,p100,p101,p111)
+		icell=icell+1;	@. cellnodes[:,icell]=(p000,p101,p100,p111)
 		icell=icell+1;	@. cellnodes[:,icell]=(p000,p010,p011,p111)
-		icell=icell+1;	@. cellnodes[:,icell]=(p000,p010,p110,p111)
+		icell=icell+1;	@. cellnodes[:,icell]=(p000,p110,p010,p111)
 		icell=icell+1;	@. cellnodes[:,icell]=(p000,p001,p101,p111)
-		icell=icell+1;	@. cellnodes[:,icell]=(p000,p001,p011,p111)
+		icell=icell+1;	@. cellnodes[:,icell]=(p000,p011,p001,p111)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,7 +416,7 @@ end
         sha256(f)
     end |> bytes2hex
 
-    @test sha_code == "93a31139ccb3ae3017351d7cef0c2639c5def97c9744699543fe8bc58e1ebcea"
+    @test sha_code == "f7e86e426aa6673699bd470f6db328a177eabdee74c71cfa6a855a2507b4f1bb"
 end
 
 

--- a/test/test_gridstuff.jl
+++ b/test/test_gridstuff.jl
@@ -154,13 +154,14 @@ function run_grid_tests()
 
     X = LinRange(0, 1, 10)
     grid = simplexgrid(X, X)
+    @test all(grid[CellVolumes] .> 0)
     sub = subgrid(grid, [2], transform=function(a,b) a[1]=b[2] end,  boundary=true)
     @test check_cellfinder(sub)
 
     grid = simplexgrid(X, X, X)
+    @test all(grid[CellVolumes] .> 0)
     sub = subgrid(grid, [5], boundary=true)
     @test check_cellfinder(sub)
-
 
     
     @test check_uniform_refinement(reference_domain(Triangle2D), false)


### PR DESCRIPTION
by permutation of cellnodes in 3D simplexgrid constructor. Now CellVolumes are all positive and respective tests were added. The test with the sha_code had to be updated.

Don't confuse with issue #14, which was for tensorized 3D grids. This one here is for direct 3D simplexgrids.