### PR TITLE
allow to change the append and compress argument of vtk_grid in writeVTK

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -16,8 +16,10 @@ exports grid and optional provided data as a vtk file
 - `grid`: grid
 
 Each '(key, value)' pair adds another data entry to the vtk file via WriteVTK functionality.
+
+For the arguments 'append' and 'compress', see documentation of vtk_grid of WriteVTK.
 """
-function writeVTK(filename::String, grid::ExtendableGrid{Tc, Ti}; kwargs...) where {Tc, Ti}
+function writeVTK(filename::String, grid::ExtendableGrid{Tc, Ti}; append = false, compress = false, kwargs...) where {Tc, Ti}
     ncells = num_cells(grid)   # get number of cells in grid
     coords = grid[Coordinates] # get coordinates 
     cells = grid[CellNodes]   # get cell-node list
@@ -31,7 +33,7 @@ function writeVTK(filename::String, grid::ExtendableGrid{Tc, Ti}; kwargs...) whe
         vtk_cells[icell] = MeshCell(VTKCellType(cell_geo[icell]), view(cells, :, icell))
     end
 
-    vtk_grid(filename, coords, vtk_cells) do vtk
+    vtk_grid(filename, coords, vtk_cells, append = append, compress = compress) do vtk
         for (key, value) in kwargs
             vtk[String(key)] = value
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,7 +416,7 @@ end
         sha256(f)
     end |> bytes2hex
 
-    @test sha_code == "f7e86e426aa6673699bd470f6db328a177eabdee74c71cfa6a855a2507b4f1bb"
+    @test sha_code == "9596c59f6b0870dd4a42a7a48725c2257f260757e15cc5ac433e5e8e235659d9"
 end
 
 


### PR DESCRIPTION
see https://juliavtk.github.io/WriteVTK.jl/dev/grids/syntax/ for the purpose of append and compress and Issue https://github.com/JuliaVTK/WriteVTK.jl/issues/136 where these somehow lead to corrupted files that cannot be opened with some paraview versions on some architectures (I have this case on my machine).

By putting the defaults of append and compress to false this issues can be avoided it seems.