### PR TITLE
Re-type argument in local-to-global transformations

### DIFF
--- a/src/l2gtransformations.jl
+++ b/src/l2gtransformations.jl
@@ -183,19 +183,19 @@ function update_trafo!(T::L2GTransformer{<:Real,<:Integer,<:Parallelepiped3D,Car
     return nothing
 end
 
-function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Vertex0D,Cartesian1D}, xref)
+function eval_trafo!(x::AbstractArray, T::L2GTransformer{<:Real,<:Integer,<:Vertex0D,Cartesian1D}, xref)
     x[1] = T.b[1]
     return nothing
 end
 
-function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Union{Triangle2D, Parallelogram2D},Cartesian2D}, xref)
+function eval_trafo!(x::AbstractArray, T::L2GTransformer{<:Real,<:Integer,<:Union{Triangle2D, Parallelogram2D},Cartesian2D}, xref)
     x[1] = T.A[1,1]*xref[1] + T.A[1,2]*xref[2] + T.b[1]
     x[2] = T.A[2,1]*xref[1] + T.A[2,2]*xref[2] + T.b[2]
     return nothing
 end
 
 
-function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Union{Triangle2D, Parallelogram2D},Cartesian3D}, xref)
+function eval_trafo!(x::AbstractArray, T::L2GTransformer{<:Real,<:Integer,<:Union{Triangle2D, Parallelogram2D},Cartesian3D}, xref)
     x[1] = T.A[1,1]*xref[1] + T.A[1,2]*xref[2] + T.b[1]
     x[2] = T.A[2,1]*xref[1] + T.A[2,2]*xref[2] + T.b[2]
     x[3] = T.A[3,1]*xref[1] + T.A[3,2]*xref[2] + T.b[3]
@@ -203,7 +203,7 @@ function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Union{Trian
 end
 
 
-function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Union{Tetrahedron3D, Parallelepiped3D},Cartesian3D}, xref)
+function eval_trafo!(x::AbstractArray, T::L2GTransformer{<:Real,<:Integer,<:Union{Tetrahedron3D, Parallelepiped3D},Cartesian3D}, xref)
     x[1] = T.A[1,1]*xref[1] + T.A[1,2]*xref[2] + T.A[1,3]*xref[3] + T.b[1]
     x[2] = T.A[2,1]*xref[1] + T.A[2,2]*xref[2] + T.A[2,3]*xref[3] + T.b[2]
     x[3] = T.A[3,1]*xref[1] + T.A[3,2]*xref[2] + T.A[3,3]*xref[3] + T.b[3]
@@ -211,18 +211,18 @@ function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Union{Tetra
 end
 
 
-function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Edge1D,Cartesian1D}, xref)
+function eval_trafo!(x::AbstractArray, T::L2GTransformer{<:Real,<:Integer,<:Edge1D,Cartesian1D}, xref)
     x[1] = T.A[1,1]*xref[1] + T.b[1]
     return nothing
 end
 
-function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Edge1D,Cartesian2D}, xref)
+function eval_trafo!(x::AbstractArray, T::L2GTransformer{<:Real,<:Integer,<:Edge1D,Cartesian2D}, xref)
     x[1] = T.A[1,1]*xref[1] + T.b[1]
     x[2] = T.A[2,1]*xref[1] + T.b[2]
     return nothing
 end
 
-function eval_trafo!(x::Vector, T::L2GTransformer{<:Real,<:Integer,<:Edge1D,Cartesian3D}, xref)
+function eval_trafo!(x::AbstractArray, T::L2GTransformer{<:Real,<:Integer,<:Edge1D,Cartesian3D}, xref)
     x[1] = T.A[1,1]*xref[1] + T.b[1]
     x[2] = T.A[2,1]*xref[1] + T.b[2]
     x[3] = T.A[3,1]*xref[1] + T.b[3]


### PR DESCRIPTION
The local-to-global `eval_trafo!` functions currently operate on the `Vector` type.

However, in trying to [extend `VoronoiFVM.edgevelocities`](https://github.com/j-fu/VoronoiFVM.jl/compare/master...Da-Be-Ru:VoronoiFVM.jl:feature/extendablefembaseext) to accomodate velocity fields provided by [`ExtendableFEM.jl`](https://github.com/chmerdon/ExtendableFEM.jl), we need to make use of coordinate transformations on vectors previously declared as `StaticArray`s which are not a subtype of `Vector`. 

It makes sense to adjust the type of `x` then and I suppose `AbstractArray` is a safe bet. All tests run through for me on this.