### PR TITLE
Add `TDict` doc entry and add a small summary

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,7 +16,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Triangulate = "f7e6ffb2-c36d-4f8f-a77e-16e897189344"
 
 [compat]
-CairoMakie = "0.12"
 Documenter = "1"
 ExampleJuggler = "2"
 julia = "1.9"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,6 +38,7 @@ function mkdocs()
             "adjacency.md",
             "vectorofconstants.md",
             "typehierarchy.md",
+            "tdict.md",
             "elementgeometry.md",
             "shape_specs.md",
             "coordinatesystem.md",


### PR DESCRIPTION
@Da-Be-Ru and I wondered about the magic behind the scenes of the type dictionary system.
We thought it might help future us and other people if we add a small summary of what is going on.
Moreover, this is now a top level doc entry, since new user also ask why we access grid components by type.

@j-fu I removed the `CairoMakie` compat in the docs. Was there a reason for that? It does not work with Julia 1.12 and I do not like compats in docs.