### PR TITLE
remove allocations from cell finder

### DIFF
--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -110,7 +110,7 @@ function gFindLocal!(xref, CF::CellFinder{Tv, Ti}, x; icellstart = 1, trybrute =
     xreftest::Array{Tv, 1} = CF.xreftest
     L2G::L2GTransformer{Tv, Ti} = CF.L2G4EG[1]
     L2Gb::Vector{Tv} = L2G.b
-    
+
     invA::Matrix{Tv} = CF.invA
     imin::Int = 0
 


### PR DESCRIPTION
The cell finder causes allocations, which affects performance of PointEvaluator or lazy_interpolate in ExtendableFEM.
So far I fixed one line that was causing 2 allocations in each call, another allocation seems to be hidden in (the call of) update_trafo! that I could not fix.