### PR TITLE
Add `explode(grid)` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [1.15.0]
+ - add and export `explode` function that produces a grid with all adjacencies removed
+
 ## [1.14.2] - 2025-11-25
 - less allocations in gFindLocal
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtendableGrids"
 uuid = "cfc395e8-590f-11e8-1f13-43a2532b2fa8"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Christian Merdon  <christian.merdon@wias-berlin.de>", "Johannes Taraz  <johannes.taraz@gmail.com>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
-version = "1.14.2"
+version = "1.15.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/more.md
+++ b/docs/src/more.md
@@ -5,3 +5,9 @@
 Modules = [ExtendableGrids]
 Pages = ["derived.jl","more.jl"]
 ```
+
+## Additional Functions
+
+```@docs
+explode
+```

--- a/src/ExtendableGrids.jl
+++ b/src/ExtendableGrids.jl
@@ -78,7 +78,7 @@ export num_cellregions, num_bfaceregions, num_bedgeregions
 export gridcomponents
 export isconsistent, dangling_nodes
 export seemingly_equal, numbers_match
-export trim!, trim
+export trim!, trim, explode
 
 include("partitioning.jl")
 export PColorPartitions, PartitionCells, PartitionBFaces, PartitionNodes, NodePermutation, PartitionEdges

--- a/test/test_explode.jl
+++ b/test/test_explode.jl
@@ -1,0 +1,25 @@
+using ExtendableGrids
+using Test
+
+@testset "explode function tests" begin
+    # create a grid
+    grid = uniform_refine(grid_unitcube(Tetrahedron3D), 3)
+
+    # Test explode function
+    exploded_grid = explode(grid)
+
+    # Verify results
+    @test num_cells(exploded_grid) == num_cells(grid)
+    @test num_nodes(exploded_grid) == 4 * num_cells(grid) # 4 tetrahedron corners for each cell
+
+    # Verify coordinates are preserved
+    original_coords = Set([Tuple(grid[Coordinates][:, i]) for i in 1:size(grid[Coordinates], 2)])
+    exploded_coords = Set([Tuple(exploded_grid[Coordinates][:, i]) for i in 1:size(exploded_grid[Coordinates], 2)])
+    @test original_coords == exploded_coords
+
+    # Verify regions are preserved
+    @test exploded_grid[CellRegions] == grid[CellRegions]
+
+    # Verify parent relation
+    @test exploded_grid[ParentGrid] === grid
+end


### PR DESCRIPTION
This creates a grid without any adjacency information form a given grid.

Cells are duplicated and each cell has independent nodes. Some properties like
- CellRegions
- BFaceRegion
- BFaceCells

are also transferred. 

I intend to use it for broken VTK exports.