### PR TITLE
consistent usage of cell indexing type (Ti instead of Int)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# [1.17.1] - 2026-05-20
+- update_trafo! of L2GTransformer does not require item to be of type Int anymore
+- CellFinder result type is always of type Ti (grid items index type)
+
 # [1.17.0] - 2026-04-15
 - new kwargs `not_in_domain_value = nothing` and `check_if_not_in_domain = isnothing(not_in_domain_value)` for grid interpolation.
   This enables the user to interpolate values between grids which do not share the same domain. The value _outside_ the target domain has to be provided by the user.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtendableGrids"
 uuid = "cfc395e8-590f-11e8-1f13-43a2532b2fa8"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Christian Merdon  <christian.merdon@wias-berlin.de>", "Johannes Taraz  <johannes.taraz@gmail.com>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
-version = "1.17.0"
+version = "1.17.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -98,8 +98,7 @@ Upon return, xref contains the barycentric coordinates of the point in the seque
 function gFindLocal!(
         xref,
         CF::CellFinder{Tv, Ti},
-        x,
-        use_typestable_api::Val{true};
+        x;
         icellstart = Ti(1),
         stay_in_cell = false,
         trybrute = true,
@@ -132,7 +131,7 @@ function gFindLocal!(
 
         # update local 2 global map
         L2G = CF.L2G4EG[cEG]
-        update_trafo!(L2G, icell, Val(true)) # 1 allocation
+        update_trafo!(L2G, icell) # 1 allocation
         L2Gb = L2G.b
 
         # compute barycentric coordinates of node
@@ -179,7 +178,7 @@ function gFindLocal!(
                     return gFindBruteForce!(xref, CF, x; eps)
                 else
                     @debug  "could not find point in any cell and ended up at boundary of domain (maybe x lies outside of the domain ?)"
-                    return 0
+                    return Ti(0)
                 end
             end
         end
@@ -189,28 +188,12 @@ function gFindLocal!(
                 return gFindBruteForce!(xref, CF, x; eps)
             else
                 @debug  "could not find point in any cell and ended up at boundary of domain (maybe x lies outside of the domain ?)"
-                return 0
+                return Ti(0)
             end
         end
     end
 
-    return 0
-end
-
-
-# Backwards compatibility with type-unstable API
-function gFindLocal!(
-        xref,
-        CF::CellFinder{Tv, Ti},
-        x,
-        use_typestable_api::Val{false} = Val(false);
-        icellstart = Ti(1),
-        stay_in_cell = false,
-        trybrute = true,
-        eps = 1.0e-14
-    ) where {Tv, Ti}
-    Base.depwarn("use the type-stable API with last argument use_typestable_api = Val(true); this returns icell::Ti !", :gFindLocal!, force = true)
-    return Int64(gFindLocal!(xref, CF, x, Val(true); icellstart, stay_in_cell, trybrute, eps))
+    return Ti(0)
 end
 
 """
@@ -226,7 +209,7 @@ Upon return, xref contains the barycentric coordinates of the point in the seque
     Currently implemented for simplex grids only.
 
 """
-function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x, use_typestable_api::Val{true}; eps = 1.0e-14) where {Tv, Ti}
+function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14) where {Tv, Ti}
 
     cx::Vector{Tv} = CF.cx
     cEG::Int = 0
@@ -248,7 +231,7 @@ function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x, use_typestable_api::V
 
         # update local 2 global map
         L2G = CF.L2G4EG[cEG]
-        update_trafo!(L2G, icell, Val(true))
+        update_trafo!(L2G, icell)
         L2Gb = L2G.b
 
         # compute barycentric coordinates of node
@@ -279,13 +262,7 @@ function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x, use_typestable_api::V
 
     @debug "gFindBruteForce did not find any cell that contains x = $x (make sure that x is inside the domain, or try reducing $eps)"
 
-    return 0
-end
-
-# Backwards compatibility with type-unstable API
-function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x, use_typestable_api::Val{false} = Val(false); eps = 1.0e-14) where {Tv, Ti}
-    Base.depwarn("use the type-stable API with last argument use_typestable_api = Val(true); this returns icell::Ti !", :gFindBruteForce!, force = true)
-    return Int64(gFindBruteForce!(xref, CF, x, Val{true}; eps))
+    return Ti(0)
 end
 
 """
@@ -320,7 +297,7 @@ function interpolate!(u_to::AbstractArray, grid_to, u_from::AbstractArray, grid_
     cf = CellFinder(grid_from)
     icellstart = 1
     for inode_to in 1:nnodes_to
-        @views icell_from = gFindLocal!(λ, cf, coord[:, inode_to], Val(true); icellstart, eps, trybrute)
+        @views icell_from = gFindLocal!(λ, cf, coord[:, inode_to]; icellstart, eps, trybrute)
         if icell_from <= 0 && !check_if_not_in_domain
             u_to[inode_to] = not_in_domain_value
         else

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -226,7 +226,7 @@ Upon return, xref contains the barycentric coordinates of the point in the seque
     Currently implemented for simplex grids only.
 
 """
-function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14) where {Tv, Ti}
+function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x, use_typestable_api::Val{true}; eps = 1.0e-14) where {Tv, Ti}
 
     cx::Vector{Tv} = CF.cx
     cEG::Int = 0
@@ -282,6 +282,11 @@ function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14) where 
     return 0
 end
 
+# Backwards compatibility with type-unstable API
+function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x, use_typestable_api::Val{false} = Val(false); eps = 1.0e-14) where {Tv, Ti}
+    Base.depwarn("use the type-stable API with last argument use_typestable_api = Val(true); this returns icell::Ti !", :gFindBruteForce!, force = true)
+    return Int64(gFindBruteForce!(xref, CF, x, Val{true}; eps))
+end
 
 """
     interpolate!(u_to,grid_to, u_from, grid_from;eps=1.0e-14,trybrute=true)
@@ -315,7 +320,7 @@ function interpolate!(u_to::AbstractArray, grid_to, u_from::AbstractArray, grid_
     cf = CellFinder(grid_from)
     icellstart = 1
     for inode_to in 1:nnodes_to
-        @views icell_from = gFindLocal!(λ, cf, coord[:, inode_to]; icellstart, eps, trybrute)
+        @views icell_from = gFindLocal!(λ, cf, coord[:, inode_to], Val(true); icellstart, eps, trybrute)
         if icell_from <= 0 && !check_if_not_in_domain
             u_to[inode_to] = not_in_domain_value
         else

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -95,7 +95,7 @@ Upon return, xref contains the barycentric coordinates of the point in the seque
 !!! warning
     Currently implemented for simplex grids only.
 """
-function gFindLocal!(xref, CF::CellFinder{Tv, Ti}, x; icellstart = 1, stay_in_cell = false, trybrute = true, eps = 1.0e-14) where {Tv, Ti}
+function gFindLocal!(xref, CF::CellFinder{Tv, Ti}, x; icellstart = Ti(1), stay_in_cell = false, trybrute = true, eps = 1.0e-14) where {Tv, Ti}
     # works for convex domains and simplices only !
     xCellFaces::Adjacency{Ti} = CF.xCellFaces
     xFaceCells::Adjacency{Ti} = CF.xFaceCells

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -95,7 +95,16 @@ Upon return, xref contains the barycentric coordinates of the point in the seque
 !!! warning
     Currently implemented for simplex grids only.
 """
-function gFindLocal!(xref, CF::CellFinder{Tv, Ti}, x; icellstart = Ti(1), stay_in_cell = false, trybrute = true, eps = 1.0e-14) where {Tv, Ti}
+function gFindLocal!(
+        xref,
+        CF::CellFinder{Tv, Ti},
+        x,
+        use_typestable_api::Val{true};
+        icellstart = Ti(1),
+        stay_in_cell = false,
+        trybrute = true,
+        eps = 1.0e-14
+    ) where {Tv, Ti}
     # works for convex domains and simplices only !
     xCellFaces::Adjacency{Ti} = CF.xCellFaces
     xFaceCells::Adjacency{Ti} = CF.xFaceCells
@@ -186,6 +195,22 @@ function gFindLocal!(xref, CF::CellFinder{Tv, Ti}, x; icellstart = Ti(1), stay_i
     end
 
     return 0
+end
+
+
+# Backwards compatibility with type-unstable API
+function gFindLocal!(
+        xref,
+        CF::CellFinder{Tv, Ti},
+        x,
+        use_typestable_api::Val{false} = Val(false);
+        icellstart = Ti(1),
+        stay_in_cell = false,
+        trybrute = true,
+        eps = 1.0e-14
+    ) where {Tv, Ti}
+    Base.depwarn("use the type-stable API with last argument use_typestable_api = Val(true); this returns icell::Ti !", :gFindLocal!, force = true)
+    return Int64(gFindLocal!(xref, CF, x, Val(true); icellstart, stay_in_cell, trybrute, eps))
 end
 
 """

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -213,7 +213,7 @@ function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14) where 
     invA::Matrix{Tv} = CF.invA
     imin::Int = 0
 
-    for icell in 1:num_sources(CF.xgrid[CellNodes])
+    for icell::Ti in 1:num_sources(CF.xgrid[CellNodes])
 
         # find current cell geometry index
         cEG = 1

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -103,7 +103,7 @@ function gFindLocal!(
         stay_in_cell = false,
         trybrute = true,
         eps = 1.0e-14
-    ) where {Tv, Ti}
+    )::Ti where {Tv, Ti}
     # works for convex domains and simplices only !
     xCellFaces::Adjacency{Ti} = CF.xCellFaces
     xFaceCells::Adjacency{Ti} = CF.xFaceCells
@@ -178,7 +178,7 @@ function gFindLocal!(
                     return gFindBruteForce!(xref, CF, x; eps)
                 else
                     @debug  "could not find point in any cell and ended up at boundary of domain (maybe x lies outside of the domain ?)"
-                    return Ti(0)
+                    return 0
                 end
             end
         end
@@ -188,12 +188,12 @@ function gFindLocal!(
                 return gFindBruteForce!(xref, CF, x; eps)
             else
                 @debug  "could not find point in any cell and ended up at boundary of domain (maybe x lies outside of the domain ?)"
-                return Ti(0)
+                return 0
             end
         end
     end
 
-    return Ti(0)
+    return 0
 end
 
 """
@@ -209,7 +209,7 @@ Upon return, xref contains the barycentric coordinates of the point in the seque
     Currently implemented for simplex grids only.
 
 """
-function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14) where {Tv, Ti}
+function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14)::Ti where {Tv, Ti}
 
     cx::Vector{Tv} = CF.cx
     cEG::Int = 0
@@ -262,7 +262,7 @@ function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14) where 
 
     @debug "gFindBruteForce did not find any cell that contains x = $x (make sure that x is inside the domain, or try reducing $eps)"
 
-    return Ti(0)
+    return 0
 end
 
 """

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -123,7 +123,7 @@ function gFindLocal!(xref, CF::CellFinder{Tv, Ti}, x; icellstart = Ti(1), stay_i
 
         # update local 2 global map
         L2G = CF.L2G4EG[cEG]
-        update_trafo!(L2G, icell) # 1 allocation
+        update_trafo!(L2G, icell, Val(true)) # 1 allocation
         L2Gb = L2G.b
 
         # compute barycentric coordinates of node
@@ -223,7 +223,7 @@ function gFindBruteForce!(xref, CF::CellFinder{Tv, Ti}, x; eps = 1.0e-14) where 
 
         # update local 2 global map
         L2G = CF.L2G4EG[cEG]
-        update_trafo!(L2G, icell)
+        update_trafo!(L2G, icell, Val(true))
         L2Gb = L2G.b
 
         # compute barycentric coordinates of node

--- a/src/cellfinder.jl
+++ b/src/cellfinder.jl
@@ -104,7 +104,7 @@ function gFindLocal!(xref, CF::CellFinder{Tv, Ti}, x; icellstart = 1, stay_in_ce
     cx::Vector{Tv} = CF.cx
     cEG::Int = 0
     facetogo::Array{Array{Ti, 1}, 1} = CF.facetogo
-    icell::Int = icellstart
+    icell::Ti = icellstart
     previous_cells::Array{Ti, 1} = CF.previous_cells
     fill!(previous_cells, 0)
     xreftest::Array{Tv, 1} = CF.xreftest

--- a/src/l2gtransformations.jl
+++ b/src/l2gtransformations.jl
@@ -39,12 +39,12 @@ function L2GTransformer(EG::Union{Type{<:Tetrahedron3D}, Type{<:Parallelepiped3D
     return L2GTransformer{Tv, Ti, EG, grid[CoordinateSystem]}(0, false, grid[Coordinates], grid[GridComponentNodes4AssemblyType(AT)], grid[GridComponentVolumes4AssemblyType(AT)], A, b, zeros(Tv, 3, 3), 0)
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Vertex0D, Cartesian1D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Vertex0D, Cartesian1D}, item::Ti) where {Ti}
     T.b[1] = T.Coords[1, T.Nodes[1, item]]
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Edge1D, Cartesian1D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -54,7 +54,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Edge1D, Cartesian1
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Edge1D, Cartesian2D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -66,7 +66,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Edge1D, Cartesian2
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Edge1D, Cartesian3D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -80,7 +80,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Edge1D, Cartesian3
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Triangle2D, Cartesian2D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -94,7 +94,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Triangle2D, Cartes
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Parallelogram2D, Cartesian2D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian2D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -108,7 +108,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Parallelogram2D, C
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Triangle2D, Cartesian3D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -125,7 +125,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Triangle2D, Cartes
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Parallelogram2D, Cartesian3D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian3D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -143,7 +143,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Parallelogram2D, C
 end
 
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Tetrahedron3D, Cartesian3D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -163,7 +163,7 @@ function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Tetrahedron3D, Car
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, <:Integer, <:Parallelepiped3D, Cartesian3D}, item::Int)
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelepiped3D, Cartesian3D}, item::Ti) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]

--- a/src/l2gtransformations.jl
+++ b/src/l2gtransformations.jl
@@ -39,19 +39,12 @@ function L2GTransformer(EG::Union{Type{<:Tetrahedron3D}, Type{<:Parallelepiped3D
     return L2GTransformer{Tv, Ti, EG, grid[CoordinateSystem]}(0, false, grid[Coordinates], grid[GridComponentNodes4AssemblyType(AT)], grid[GridComponentVolumes4AssemblyType(AT)], A, b, zeros(Tv, 3, 3), 0)
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Vertex0D, Cartesian1D}, item::Ti) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Vertex0D, Cartesian1D}, item) where {Ti}
     T.b[1] = T.Coords[1, T.Nodes[1, item]]
     return nothing
 end
 
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -61,13 +54,7 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, ite
     return nothing
 end
 
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -79,13 +66,7 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, ite
     return nothing
 end
 
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -99,13 +80,7 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, ite
     return nothing
 end
 
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -119,13 +94,8 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D},
     return nothing
 end
 
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian2D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian2D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian2D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -139,14 +109,7 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesia
     return nothing
 end
 
-
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -163,14 +126,7 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D},
     return nothing
 end
 
-
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian3D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -187,13 +143,7 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesia
     return nothing
 end
 
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -213,14 +163,7 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3
     return nothing
 end
 
-
-# Backwards compatibility overload for non-type-stable API
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelepiped3D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
-    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
-    return update_trafo!(T, Ti(item), Val(true))
-end
-
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelepiped3D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelepiped3D, Cartesian3D}, item) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]

--- a/src/l2gtransformations.jl
+++ b/src/l2gtransformations.jl
@@ -16,7 +16,7 @@
 Transforms reference coordinates to global coordinates
 """
 mutable struct L2GTransformer{Tv <: Real, Ti <: Integer, EG <: AbstractElementGeometry, CS <: AbstractCoordinateSystem}
-    citem::Int
+    citem::Ti
     nonlinear::Bool # so that users know if derivatives of map change in every quadrature point of cell or not
     Coords::Array{Tv, 2}
     Nodes::Adjacency{Ti}

--- a/src/l2gtransformations.jl
+++ b/src/l2gtransformations.jl
@@ -44,7 +44,14 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Vertex0D, Cartesian1D}, i
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, item::Ti) where {Ti}
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -54,7 +61,13 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian1D}, ite
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, item::Ti) where {Ti}
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -66,7 +79,13 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian2D}, ite
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, item::Ti) where {Ti}
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -80,7 +99,13 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Edge1D, Cartesian3D}, ite
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D}, item::Ti) where {Ti}
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -94,7 +119,13 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian2D},
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian2D}, item::Ti) where {Ti}
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian2D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian2D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -108,7 +139,14 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesia
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D}, item::Ti) where {Ti}
+
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -125,7 +163,14 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Triangle2D, Cartesian3D},
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian3D}, item::Ti) where {Ti}
+
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -142,8 +187,13 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelogram2D, Cartesia
     return nothing
 end
 
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3D}, item::Ti) where {Ti}
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]
@@ -163,7 +213,14 @@ function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Tetrahedron3D, Cartesian3
     return nothing
 end
 
-function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelepiped3D, Cartesian3D}, item::Ti) where {Ti}
+
+# Backwards compatibility overload for non-type-stable API
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelepiped3D, Cartesian3D}, item::Int, use_typestable_api::Val{false} = Val(false)) where {Ti <: Integer}
+    Base.depwarn("use the type-stable API: typeof(item) must match the L2GTransformer Ti type", :update_trafo!, force = true)
+    return update_trafo!(T, Ti(item), Val(true))
+end
+
+function update_trafo!(T::L2GTransformer{<:Real, Ti, <:Parallelepiped3D, Cartesian3D}, item::Ti, use_typestable_api::Val{true}) where {Ti}
     if T.citem != item
         T.citem = item
         T.b[1] = T.Coords[1, T.Nodes[1, item]]

--- a/test/test_gridstuff.jl
+++ b/test/test_gridstuff.jl
@@ -97,7 +97,7 @@ function check_cellfinder(xgrid)
     # check xref
     x = zeros(Float64, edim)
     L2G = L2GTransformer(xgrid[CellGeometries][cell], xgrid, ON_CELLS)
-    update_trafo!(L2G, cell)
+    update_trafo!(L2G, cell, Val(true))
     eval_trafo!(x, L2G, xref)
 
     @info "... found x=$x in cell = $cell by local search (and had to find x=$x_source in cell=$cell_to_find)"
@@ -109,7 +109,7 @@ function check_cellfinder(xgrid)
 
     # check xref
     x = zeros(Float64, edim)
-    update_trafo!(L2G, cell)
+    update_trafo!(L2G, cell, Val(true))
     eval_trafo!(x, L2G, xref)
 
     @info "... found x=$x in cell = $cell by brute force (and had to find  x=$x_source in cell=$cell_to_find)"

--- a/test/test_gridstuff.jl
+++ b/test/test_gridstuff.jl
@@ -92,7 +92,7 @@ function check_cellfinder(xgrid)
     @show x_source
     # find cell by local strategy
     xref = zeros(Float64, edim + 1)
-    cell = gFindLocal!(xref, CF, x_source; icellstart = 1)
+    cell = gFindLocal!(xref, CF, x_source, Val(true); icellstart = 1)
 
     # check xref
     x = zeros(Float64, edim)
@@ -105,7 +105,7 @@ function check_cellfinder(xgrid)
     @assert cell == cell_to_find
 
     # find cell again by brute force
-    cell = gFindBruteForce!(xref, CF, x_source)
+    cell = gFindBruteForce!(xref, CF, x_source, Val(true))
 
     # check xref
     x = zeros(Float64, edim)

--- a/test/test_gridstuff.jl
+++ b/test/test_gridstuff.jl
@@ -92,12 +92,12 @@ function check_cellfinder(xgrid)
     @show x_source
     # find cell by local strategy
     xref = zeros(Float64, edim + 1)
-    cell = gFindLocal!(xref, CF, x_source, Val(true); icellstart = 1)
+    cell = gFindLocal!(xref, CF, x_source; icellstart = 1)
 
     # check xref
     x = zeros(Float64, edim)
     L2G = L2GTransformer(xgrid[CellGeometries][cell], xgrid, ON_CELLS)
-    update_trafo!(L2G, cell, Val(true))
+    update_trafo!(L2G, cell)
     eval_trafo!(x, L2G, xref)
 
     @info "... found x=$x in cell = $cell by local search (and had to find x=$x_source in cell=$cell_to_find)"
@@ -105,11 +105,11 @@ function check_cellfinder(xgrid)
     @assert cell == cell_to_find
 
     # find cell again by brute force
-    cell = gFindBruteForce!(xref, CF, x_source, Val(true))
+    cell = gFindBruteForce!(xref, CF, x_source)
 
     # check xref
     x = zeros(Float64, edim)
-    update_trafo!(L2G, cell, Val(true))
+    update_trafo!(L2G, cell)
     eval_trafo!(x, L2G, xref)
 
     @info "... found x=$x in cell = $cell by brute force (and had to find  x=$x_source in cell=$cell_to_find)"


### PR DESCRIPTION
in downstream packages like ExtendableFEMBase there is always confusion about with which index type a cell should be identified, sometimes it is the Ti type of the grid, sometimes it is just Int. This is mainly caused by the update_trafo functions of the l2gtransformer in ExtendableGrids, which enforces the cell index to be of type Int, although in the grid storages cells are indexed with the the type Ti. 

With this PR all functions in ExtendableGrids now use the Ti type consistently. Unfortunately, this might cause some downstream assembly loops to crash and requires an update there as well. However, I think this should be done to avoid confusion in future and probably, when fixed there as well, this will also remove some allocations, e.g. in lazy_interpolate! of ExtendableFEMBase.

Update: Instead of enforcing Ti everywhere, type annotations have been removed to allow for Ti (and not enforce Int anymore)